### PR TITLE
update to airdrop analytic to ignore user library sharing directory

### DIFF
--- a/custom_analytic_detections/airdrop_event_inbound
+++ b/custom_analytic_detections/airdrop_event_inbound
@@ -5,12 +5,12 @@
 #
 # Analytic Predicate:
 
-$event.type == 3 AND $event.prevFile BEGINSWITH "/private/var/folders/" AND NOT $event.path BEGINSWITH "/var/folders/" AND $event.process.signingInfo.appid == "com.apple.sharingd"
+$event.type == 3 AND $event.prevFile BEGINSWITH "/private/var/folders/" AND NOT $event.path MATCHES "(/Users/[^/]+/Library/Sharing/|/var/folders/).*" AND $event.process.signingInfo.appid == "com.apple.sharingd"
 
 # Required Analytic Configuration:
 
 Sensor Event Type: GPFSEvent
-Level: 1
+Level: 0
 
 # Recommended Analytic Configuration:
 Severity: Informational


### PR DESCRIPTION
- Airdrop analytic was triggering on the `pairing-records.plist` in the `~/Library/Sharing/AutoUnlock` directory. 
- Fix ignores the directory as this directory is only used for pairing an Apple Watch to the Mac to unlock the device via the Apple Watch. This process is signed by `com.apple.sharingd`, causing the analytic to trigger.
- Updated regex to ignore aforementioned directory 
- Dropping from a level 1 analytic to a level 0