### PR TITLE
New and modified Unified Log filters

### DIFF
--- a/unified_log_filters/.template_unified_log_filter
+++ b/unified_log_filters/.template_unified_log_filter
@@ -15,3 +15,7 @@
 
 # <insert additional information and usage instructions here>
 
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+Yes / No

--- a/unified_log_filters/airdrop_transfer_inbound
+++ b/unified_log_filters/airdrop_transfer_inbound
@@ -1,8 +1,0 @@
-# airdrop_transfer_inbound
-#
-# This Unified Log filter may be used to report on AirDrop transfer events originating from the endpoint.
-# This filter functions by monitoring logging from the sharingd process, it's related subsystem and for event messaging containing a known string indicating an AirDrop transfer has been initiated.
-#
-# Filter Predicate:
-
-process == "sharingd" and subsystem = "com.apple.sharing" and category = "AirDrop" and composedMessage BEGINSWITH[cd] "startSending"

--- a/unified_log_filters/airdrop_transfer_outbound
+++ b/unified_log_filters/airdrop_transfer_outbound
@@ -1,0 +1,21 @@
+# airdrop_transfer_outbound
+#
+# This Unified Log filter may be used to report on outbound AirDrop file transfers from the Mac.
+# This filter functions by monitoring logging from an AirDrop process spawning from a valid location and a logged string known to indicate an outbound file transfer was offered.
+
+# Filter Predicate(s):
+
+subsystem == "com.apple.sharing" AND process == "AirDrop" AND processImagePath BEGINSWITH "/System/Library" AND eventMessage BEGINSWITH "Successfully issued sandbox extension for"
+
+# Example output:
+
+2021-XX-XX XX:XX:XX.205187+0000 XXXXXXX Default XXXXXXX 27436 0 AirDrop: (Sharing) [com.apple.sharing:Framework] Successfully issued sandbox extension for /Users/username/Documents/sensitiveData.pdf
+
+# Additional Information:
+
+The file path in the log message is that of the file that was shared via the outbound AirDrop transfer.  Please also note that this filter will trigger as soon as the Mac user selects a target device in the AirDrop share menu, regardless of whether that user then chooses to accept or deny the transfer.
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No

--- a/unified_log_filters/gatekeeper_bypassed_by_user_during_file_access
+++ b/unified_log_filters/gatekeeper_bypassed_by_user_during_file_access
@@ -1,8 +1,0 @@
-# gatekeeper_bypassed_by_user_during_file_access
-#
-# This Unified Log filter may be used to report on events where a user bypassed Gatekeeper to open a file.
-# This filter functions by monitoring logging containing event messaging with a known string indicating a bypass event occurred.  Please note that the typo in 'sucessfully' is required due to a typo in macOS logging.
-#
-# Filter Predicate:
-
-eventMessage = "Cleared Gatekeeper rejection record sucessfully"

--- a/unified_log_filters/gatekeeper_file_access_rejections_and_user_bypasses
+++ b/unified_log_filters/gatekeeper_file_access_rejections_and_user_bypasses
@@ -1,0 +1,24 @@
+# gatekeeper_file_apen_rejections_and_user_bypasses
+#
+# This Unified Log filter may be used to report on events where a user is prevented from accessing a file by double-click, as well as when that user then right-click and chooses to bypass Gatekeeper to open the file anyway.
+# This filter functions by monitoring logging containing event messaging with a known string indicating a bypass event occurred.  Please note that the typo in 'sucessfully' is required due to a typo in macOS logging.
+#
+# Filter Predicate:
+
+subsystem == "com.apple.launchservices" AND process == "CoreServicesUIAgent" AND category == "uiagent" AND (eventMessage BEGINSWITH "Saving rejection record:" OR eventMessage CONTAINS "Gatekeeper rejection record")
+
+# Example Output:
+
+2021-XX-XX XX:XX:XX.849161-0800 XXXXXX Default 0x0 597 0 CoreServicesUIAgent: [com.apple.launchservices:uiagent] Saving rejection record:
+Rejected URL=file:///Volumes/VolumeName/PackageName.pkg
+App URL=file:///System/Library/CoreServices/Installer.app/
+2021-XX-XX XX:XX:XX.905569-0800 XXXXXX Default 0x0 597 0 CoreServicesUIAgent: [com.apple.launchservices:uiagent] Cleared Gatekeeper rejection record sucessfully
+
+# Additional Information
+
+n/a
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+Yes

--- a/unified_log_filters/gatekeeper_file_access_scan_activity
+++ b/unified_log_filters/gatekeeper_file_access_scan_activity
@@ -1,0 +1,26 @@
+# gatekeeper_file_access_scan_activity
+#
+# This Unified Log filter may be used to report on Gatekeeper scanning activity when a file is opened.
+# This filter functions by monitoring logging from the subsystem, process and category known to be used for log entries from this activity.
+
+# Filter Predicate(s):
+
+subsystem == "com.apple.syspolicy.exec" AND process == "syspolicyd" AND category == "default"
+
+# Example output:
+
+2021-XX-XX XX:XX:XX.679936+0000 XXXXXXX Default 0x0 368    0    syspolicyd: [com.apple.syspolicy.exec:default] GK performScan: PST: (path: /Applications/AppName.app), (team: (null)), (id: (null)), (bundle_id: (null))
+2021-XX-XX XX:XX:XX.168070+0000 XXXXXXX Default 0x0 368    0    syspolicyd: [com.apple.syspolicy.exec:default] GK evaluateScanResult: 0, PST: (path: /Applications/AppName.app), (team: XXXXXXXXXX), (id: com.company.domain), (bundle_id: com.app.domain), 1, 0, 1, 0, 4, 0
+2021-XX-XX XX:XX:XX.168323+0000 XXXXXXX Default 0x0 368    0    syspolicyd: [com.apple.syspolicy.exec:default] Prompt shown (5, 0), waiting for response: PST: (path: /Applications/AppName.app), (team: XXXXXXXXXX), (id: com.company.domain), (bundle_id: com.app.domain)
+2021-XX-XX XX:XX:XX.835865+0000 XXXXXXX Default 0x0 368    0    syspolicyd: [com.apple.syspolicy.exec:default] Code evaluation completed: 2
+2021-XX-XX XX:XX:XX.835947+0000 XXXXXXX Default 0x0 368    0    syspolicyd: [com.apple.syspolicy.exec:default] Allowing code due to user approval
+2021-XX-XX XX:XX:XX.887844+0000 XXXXXXX Default 0x0 368    0    syspolicyd: [com.apple.syspolicy.exec:default] Marked application as user approved: 1, PST: (path: /Applications/AppName.app), (team: XXXXXXXXXX), (id: com.company.domain), (bundle_id: com.app.domain)
+
+# Additional Information:
+
+n/a
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+Yes

--- a/unified_log_filters/jamf_pro/jamf_pro_management_binary_logging
+++ b/unified_log_filters/jamf_pro/jamf_pro_management_binary_logging
@@ -1,0 +1,21 @@
+# jamf_pro_management_binary_logging
+#
+# This Unified Log filter may be used to report on the activity and logging of the Jamf Pro management binary on a managed Mac and is the same information sent by the binary to /var/log/jamf.log on each endpoint.
+# This filter functions by monitoring logging from the jamf binary process, subsystem and with a process path that matches the valid jamf binary.
+
+# Filter Predicate(s):
+
+subsystem == "com.jamf.management.binary" AND process == "jamf" AND processImagePath == "/usr/local/jamf/bin/jamf"
+
+# Example output:
+
+Review /var/log/jamf.log from a Mac endpoint managed by Jamf Pro to see expected log entries.
+
+# Additional Information:
+
+n/a
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+ No

--- a/unified_log_filters/jamf_pro/jamf_pro_management_framework_removal
+++ b/unified_log_filters/jamf_pro/jamf_pro_management_framework_removal
@@ -5,4 +5,16 @@
 #
 # Filter Predicate:
 
-(subsystem =="com.jamf.management.binary" AND eventMessage CONTAINS "Removing JAMF Preferences file") || (subsystem == "com.jamf.management.binary" and eventMessage CONTAINS "Removing JAMF Daemon Log files") || (subsystem == "com.jamf.management.binary" and eventMessage CONTAINS "Removing self service") || (subsystem == "com.jamf.management.binary" and eventMessage CONTAINS "Removing scheduled tasks")
+subsystem == "com.jamf.management.binary" AND process == "jamf" AND processImagePath == "/usr/local/jamf/bin/jamf" AND (eventMessage CONTAINS "Removing JAMF Preferences file" OR eventMessage CONTAINS "Removing JAMF Daemon Log files" OR eventMessage CONTAINS "Removing self service" OR eventMessage CONTAINS "Removing scheduled tasks")
+
+# Example Output:
+n/a
+
+# Additional Information:
+
+n/a
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No

--- a/unified_log_filters/network_server_connection_attempts_outbound
+++ b/unified_log_filters/network_server_connection_attempts_outbound
@@ -1,0 +1,22 @@
+# network_server_connection_attempts_outbound
+#
+# This Unified Log filter may be used to report on network server connection attempts from the Mac endpoint, such as mounting an SMB share or connecting to an FTP server through Finder's Connect to Server service.
+# This filter functions by monitoring logging from NetAuthSysAgent, the process used for these connections.
+
+# Filter Predicate(s):
+
+process == "NetAuthSysAgent" AND subsystem == "com.apple.NetAuthAgent" AND category == "IPC" AND eventMessage BEGINSWITH "URL = "
+
+# Example output:
+
+2021-XX-XX XX:XX:XX.676891+0000 XXXXXXX Default XXXXXXX XXXX 0 NetAuthSysAgent: (loginsupport) [com.apple.NetAuthAgent:IPC] URL = smb://127.0.0.1
+2021-XX-XX XX:XX:XX.676891+0000 XXXXXXX Default XXXXXXX XXXX 0 NetAuthSysAgent: (loginsupport) [com.apple.NetAuthAgent:IPC] URL = ftp://127.0.0.1
+
+# Additional Information:
+
+Log entries will appear from connection attempts rather than completed, successful connections.
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No

--- a/unified_log_filters/screen_sharing_connectons_inbound
+++ b/unified_log_filters/screen_sharing_connectons_inbound
@@ -1,0 +1,22 @@
+# screen_sharing_connections_inbound
+#
+# This Unified Log filter may be used to report on inbound screen sharing connections to the endpoint made through the native screensharing client on Mac, both successful and failed.
+# This filter functions by monitoring logging from the screensharingd process and an event message containing a string known to indicate an inbound authentication event.
+
+# Filter Predicate(s):
+
+process == "screensharingd" AND eventMessage BEGINSWITH "Authentication: "
+
+# Example output:
+
+2021-XX-XX XX:XX:XX.926947-0800 XXXXXX  Default XXX XXX    0    screensharingd: Authentication: SUCCEEDED :: User Name: <username> :: Viewer Address: <ip-address> :: Type: N/A
+2021-XX-XX XX:XX:XX.807859-0800 XXXXXX  Default XXX XXX    0    screensharingd: Authentication: FAILED :: User Name: N/A :: Viewer Address: <ip-address> :: Type: N/A
+
+# Additional Information:
+
+n/a
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+Yes

--- a/unified_log_filters/third_party/sap_privileges_user_rights_elevations_and_demotions
+++ b/unified_log_filters/third_party/sap_privileges_user_rights_elevations_and_demotions
@@ -1,0 +1,22 @@
+# sap_privileges_user_rights_elevations_and_demotions
+#
+# This Unified Log filter may be used to report on logging from SAP Privileges.app.
+# This filter functions by monitoring logging from corp.sap.privileges.helper process and event messages containing SAPCorp.
+
+# Filter Predicate(s):
+
+process == "corp.sap.privileges.helper" AND eventMessage CONTAINS "SAPCorp"
+
+# Example output:
+
+2021-12-15 09:52:30.905329-0500  xxxxxx corp.sap.privileges.helper[9364]: SAPCorp: User <username> has now standard user rights
+2021-12-15 09:53:31.734594-0500  xxxxxx corp.sap.privileges.helper[9398]: SAPCorp: User <username> has now admin rights
+
+# Additional Information:
+
+https://github.com/SAP/macOS-enterprise-privileges/wiki/Frequently-Asked-Questions
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No


### PR DESCRIPTION
New Unified Log filters:
- airdrop_transfer_outbound
- gatekeeper_file_access_scan_activity
- jamf_pro/jamf_pro_management_binary_logging
- network_server_connection_attempts_outbound
- screen_sharing_connectons_inbound
- third_party/sap_privileges_user_rights_elevations_and_demotions

Modified Unified Log filters:
- gatekeeper_file_access_rejections_and_user_bypasses  (additional logic)
- jamf_pro/jamf_pro_management_framework_removal  (additional logic)

Deleted Unified Log filters:
- airdrop_transfer_inbound (invalid predicate)