### PR TITLE
Updates to two existing filters and a new filter for root user activity

### DIFF
--- a/unified_log_filters/login_through_login_window_with_password_failure
+++ b/unified_log_filters/login_through_login_window_with_password_failure
@@ -2,7 +2,11 @@
 #
 # This Unified Log filter may be used to report on failed login attempts with a password at the macOS login window.
 # This filter functions by monitoring logging from loginwindow process where the event messaging contains a known string indicating a failed login attempt with the password.
+# 
+# Tested macOS Versions:
+# - macOS 11 and below
 #
 # Filter Predicate:
 
 process == "loginwindow" AND eventMessage CONTAINS[c] "INCORRECT"
+

--- a/unified_log_filters/login_through_login_window_with_password_success
+++ b/unified_log_filters/login_through_login_window_with_password_success
@@ -5,4 +5,13 @@
 #
 # Filter Predicate:
 
-process == "loginwindow" AND eventMessage CONTAINS[c] "Unlock succeeded, with password, attempting to unlock the login keychain"
+processImagePath BEGINSWITH "/System/Library/CoreServices" AND process == "loginwindow" AND subsystem == "com.apple.loginwindow.logging" AND eventMessage CONTAINS "[Login1 doLogin] | shortUsername"
+
+# Example output:
+
+2022-XX-XX XX:XX:XX.757619-0800 XXXXXX Default XXX XXXX 0 loginwindow: [com.apple.loginwindow.logging:Standard] -[Login1 doLogin] | shortUsername = username-here, userID = 501, groupID = XX
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+Yes

--- a/unified_log_filters/root_user_enabled_or_password_changed
+++ b/unified_log_filters/root_user_enabled_or_password_changed
@@ -1,0 +1,24 @@
+# root_user_enabled_or_password_changed
+#
+# This Unified Log filter may be used to report on the root user being enabled or a password change event for a root user already enabled.
+# This filter functions by monitoring logging from the opendirectoryd process with a string message known to indicate these events.
+#
+# Tested macOS Versions:
+# - macOS 12
+#
+# Filter Predicate(s):
+
+processImagePath == "/usr/libexec/opendirectoryd" AND process == "opendirectoryd" AND subsystem == "com.apple.opendirectoryd" AND eventMessage CONTAINS "Password changed for root"
+
+# Example output:
+
+2022-XX-XX XX:XX:XX.212488-0800 XXXXXX Default XXXXXXX 318 0 opendirectoryd: (PlistFile) [com.apple.opendirectoryd:auth] Password changed for root (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)
+
+# Additional Information:
+
+# <insert additional information and usage instructions here>
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No


### PR DESCRIPTION
- Updated login_through_login_window_with_password_success to provide better data, such as username
- Updated login_through_login_window_with_password_failure to note that it's tested working only on macOS 11 and below
- Added new filter for tracking root user enablement or password changes