### PR TITLE
Task/11 2 22 new unified log filters and fixes

### DIFF
--- a/unified_log_filters/lock_screen_unlock_failure
+++ b/unified_log_filters/lock_screen_unlock_failure
@@ -11,6 +11,10 @@
 
 processImagePath BEGINSWITH "/System/Library/CoreServices" AND process == "loginwindow" AND eventMessage CONTAINS[c] "INCORRECT"
 
+# Example output:
+
+2022-XX-XX XX:XX:XX.233347-0800 XXXXXX Default XXX 1322 0 loginwindow: [com.apple.loginwindow.logging:Standard] -[LWDefaultScreenLockUI authFailWithMessage:] | enter. INCORRECT password
+
 # Additional Information:
 
 Useful for identifying frequent failed screen unlock attempts.

--- a/unified_log_filters/lock_screen_unlock_failure
+++ b/unified_log_filters/lock_screen_unlock_failure
@@ -1,0 +1,22 @@
+# lock_screen_unlock_failure
+#
+# This Unified Log filter may be used to report on failed unlock attempts at the macOS lock screen.
+# This filter functions by monitoring logging from loginwindow process where the event messaging contains a known string indicating a failed unlock attempt.
+# 
+# Tested macOS Versions:
+# - macOS 12
+# - macOS 11
+#
+# Filter Predicate:
+
+processImagePath BEGINSWITH "/System/Library/CoreServices" AND process == "loginwindow" AND eventMessage CONTAINS[c] "INCORRECT"
+
+# Additional Information:
+
+Useful for identifying frequent failed screen unlock attempts.
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No
+

--- a/unified_log_filters/login_through_login_window_with_password_failure
+++ b/unified_log_filters/login_through_login_window_with_password_failure
@@ -2,7 +2,11 @@
 #
 # This Unified Log filter may be used to report on failed login attempts with a password at the macOS login window.
 # This filter functions by monitoring logging from loginwindow process where the event messaging contains a known string indicating a failed login attempt with the password.
+# 
+# Tested macOS Versions:
+# - macOS 11 and below
 #
 # Filter Predicate:
 
 process == "loginwindow" AND eventMessage CONTAINS[c] "INCORRECT"
+

--- a/unified_log_filters/login_through_login_window_with_password_failure
+++ b/unified_log_filters/login_through_login_window_with_password_failure
@@ -10,6 +10,10 @@
 
 processImagePath BEGINSWITH "/System/" AND process == "SecurityAgent" AND subsystem == "com.apple.loginwindow" AND eventMessage CONTAINS "Authentication failure"
 
+# Example output:
+
+2022-XX-XX XX:XX:XX.851740-0800 XXXXXX Default 0x0 1333 0 SecurityAgent: (loginsupport) [com.apple.loginwindow:Process] Authentication failure type = 3
+
 # Additional Information:
 
 Useful for identifying frequent failed user login attempts.

--- a/unified_log_filters/login_through_login_window_with_password_failure
+++ b/unified_log_filters/login_through_login_window_with_password_failure
@@ -4,9 +4,18 @@
 # This filter functions by monitoring logging from loginwindow process where the event messaging contains a known string indicating a failed login attempt with the password.
 # 
 # Tested macOS Versions:
-# - macOS 11 and below
+# - macOS 12
 #
 # Filter Predicate:
 
-process == "loginwindow" AND eventMessage CONTAINS[c] "INCORRECT"
+processImagePath BEGINSWITH "/System/" AND process == "SecurityAgent" AND subsystem == "com.apple.loginwindow" AND eventMessage CONTAINS "Authentication failure"
+
+# Additional Information:
+
+Useful for identifying frequent failed user login attempts.
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No
 

--- a/unified_log_filters/login_through_login_window_with_password_success
+++ b/unified_log_filters/login_through_login_window_with_password_success
@@ -5,4 +5,13 @@
 #
 # Filter Predicate:
 
-process == "loginwindow" AND eventMessage CONTAINS[c] "Unlock succeeded, with password, attempting to unlock the login keychain"
+processImagePath BEGINSWITH "/System/Library/CoreServices" AND process == "loginwindow" AND subsystem == "com.apple.loginwindow.logging" AND eventMessage CONTAINS "[Login1 doLogin] | shortUsername"
+
+# Example output:
+
+2022-XX-XX XX:XX:XX.757619-0800 XXXXXX Default XXX XXXX 0 loginwindow: [com.apple.loginwindow.logging:Standard] -[Login1 doLogin] | shortUsername = username-here, userID = 501, groupID = XX
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+Yes

--- a/unified_log_filters/root_user_enabled_or_password_changed
+++ b/unified_log_filters/root_user_enabled_or_password_changed
@@ -1,0 +1,24 @@
+# root_user_enabled_or_password_changed
+#
+# This Unified Log filter may be used to report on the root user being enabled or a password change event for a root user already enabled.
+# This filter functions by monitoring logging from the opendirectoryd process with a string message known to indicate these events.
+#
+# Tested macOS Versions:
+# - macOS 12
+#
+# Filter Predicate(s):
+
+processImagePath == "/usr/libexec/opendirectoryd" AND process == "opendirectoryd" AND subsystem == "com.apple.opendirectoryd" AND eventMessage CONTAINS "Password changed for root"
+
+# Example output:
+
+2022-XX-XX XX:XX:XX.212488-0800 XXXXXX Default XXXXXXX 318 0 opendirectoryd: (PlistFile) [com.apple.opendirectoryd:auth] Password changed for root (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)
+
+# Additional Information:
+
+# <insert additional information and usage instructions here>
+
+# Private Data Expected
+# See https://github.com/jamf/jamfprotect/wiki/Unified-Log-Filtering
+
+No


### PR DESCRIPTION
- Added new filter for detecting root user enablement or password change
- Fixed existing filter for failed user logins at the login window
- Enriched existing filter for successful user logins at the login window
- Added new filter for failed lock screen unlock attempts