### PR TITLE
New custom analytics

### DIFF
--- a/custom_analytic_detections/all_caffeinate_activity_on_interactive_command_line
+++ b/custom_analytic_detections/all_caffeinate_activity_on_interactive_command_line
@@ -1,0 +1,19 @@
+# all_caffeinate_activity_on_interactive_command_line
+#
+# This Custom Analytic may be used to report on all usage of the 'caffeinate' binary on an interactive command line such as Terminal or through a script.
+# This detection functions by monitoring for process spawns by a binary with the 'caffeinate' app ID that have an associated tty and a parent process that is a shell.
+
+# The 'caffeinate' binary is commonly used to alter system sleep behaviour and may leave a system awake and unlocked.
+
+# Analytic Predicate(s):
+
+$event.type == 1 AND $event.process.tty != nil AND $event.process.parent.isShell == 1 AND $event.process.signingInfo.appid == "com.apple.caffeinate"
+
+# Required Analytic Configuration:
+
+Sensor Event Type: Process Event
+
+# Recommended Analytic Configuration:
+
+Severity: Informational
+Level: 0

--- a/custom_analytic_detections/system_config_activity/file_sharing_config_changes
+++ b/custom_analytic_detections/system_config_activity/file_sharing_config_changes
@@ -5,15 +5,15 @@
 
 # Analytic Predicate(s):
 
-File Sharing Disabled
-$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND $event.process.args CONTAINS[cd] "unload" AND $event.process.args CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
-
 File Sharing Enabled
-$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND $event.process.args CONTAINS[cd] "load" AND $event.process.args CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND $event.process.commandLine CONTAINS[cd] " load " AND $event.process.commandLine CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+
+File Sharing Disabled
+$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND $event.process.commandLine CONTAINS[cd] " unload " AND $event.process.commandLine CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
 
 # Required Analytic Configuration:
 
-Sensor Event Type: GPProcessEvent
+Sensor Event Type: Process Event
 
 # Recommended Analytic Configuration:
 

--- a/custom_analytic_detections/system_config_activity/file_sharing_config_changes
+++ b/custom_analytic_detections/system_config_activity/file_sharing_config_changes
@@ -1,0 +1,21 @@
+# file_sharing_config_changes
+#
+# This Custom Analytic may be used to report on File Sharing (smbd) being enabled or disabled on the host endpoint.
+# This detection functions by monitoring for a launchctl command executed by macOS when a user toggles the File Sharing feature off or on inside System Preferences > Sharing.
+
+# Analytic Predicate(s):
+
+File Sharing Disabled
+$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND $event.process.args CONTAINS[cd] "unload" AND $event.process.args CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+
+File Sharing Enabled
+$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND $event.process.args CONTAINS[cd] "load" AND $event.process.args CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+
+# Required Analytic Configuration:
+
+Sensor Event Type: GPProcessEvent
+
+# Recommended Analytic Configuration:
+
+Severity: Informational
+Level: 0

--- a/custom_analytic_detections/system_config_activity/root_user_enabled_or_password_changed
+++ b/custom_analytic_detections/system_config_activity/root_user_enabled_or_password_changed
@@ -1,0 +1,18 @@
+# root_user_enabled_or_password_changed
+#
+# This Custom Analytic may be used to report on the root user being enabled or the password of an already enabled root user being changed.  This Custom Analytic will detect this activity regardless of being completed via the 'dsenableroot' binary or via Directory Utility.app.
+# This detection functions by monitoring for expected changes made to the /var/db/dslocal/nodes/Default/users/root.plist file when these events occur.
+
+# Analytic Predicate(s):
+
+$event.path == "/var/db/dslocal/nodes/Default/users/root.plist" AND $event.isModified == 1 AND $event.file.contentsAsDict.accountPolicyData.asPlistDict.passwordLastSetTime != $event.file.snapshotData.asPlistDict.accountPolicyData.asPlistDict.passwordLastSetTime
+
+# Required Analytic Configuration:
+
+Snapshot File Path: /var/db/dslocal/nodes/Default/users/root.plist
+Sensor Event Type: File System Event
+
+# Recommended Analytic Configuration:
+
+Severity: Low
+Level: 0

--- a/custom_analytic_detections/xattr_extended_attributes_activity
+++ b/custom_analytic_detections/xattr_extended_attributes_activity
@@ -1,0 +1,23 @@
+# xattr_extended_attributes_activity
+#
+# These Custom Analytics may be used to report on activity of the xattr binary used to clear all extended attributes or the com.apple.quarantine extended attribute from files.
+# This detection functions by monitoring for usage of the xattr binary with the -c and -d args (with com.apple.quarantine) used to clear all or a target extended attribute from a file .
+
+# The com.apple.quarantine Extended Attributre is used by macOS to trigger both a user confirmation prompt and Gatekeeper scans upon first opening of a downloaded file.
+
+# Analytic Predicate(s):
+
+# All Extended Attributes (-c arg) or com.apple.quarantine Extended Attribute (-d com.apple.quarantine arg) cleared
+$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xattr" AND $event.process.commandLine MATCHES "xattr\\s+(-[lrsvx]{0,5}\\s+){0,5}((.*\\s+)?-[lrsvx]{0,5}c[lrsvxc]{0,5}(\\s.*)?|-[rsvx]{0,4}d[rsvxd]{0,5}\\s+(-[lrsvxd]{0,5}\\s+){0,5}(\"|\')?com\\.apple\\.quarantine(\"|\')?\\s.+)"
+
+# Only com.apple.quarantine Extended Attribute (-d com.apple.quarantine) cleared
+$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.xattr" AND $event.process.commandLine CONTAINS "com.apple.quarantine" AND $event.process.commandLine MATCHES "xattr\\s+(-[lrsvx]{0,5}\\s+){0,5}-[rsvx]{0,4}d[rsvxd]{0,5}\\s+(-[lrsvxd]{0,5}\\s+){0,5}(\"|\')?com\\.apple\\.quarantine(\"|\')?\\s.+"
+
+# Required Analytic Configuration:
+
+Sensor Event Type: Process Event
+
+# Recommended Analytic Configuration:
+
+Severity: Informational
+Level: 0


### PR DESCRIPTION
New custom analytics to report on:
- usage of the caffeinate binary on an interactive command line, due to a concern where a user may leave their machine awake and unlocked
- file sharing being enabled or disabled
- the root user being enabled or the password of an enabled root user being changed
- suspicious xattr activity where either all extended attributes are cleared or the com.apple.quarantine attribute cleared from a file