### PR TITLE
Update adhoc_codesigning

### DIFF
--- a/custom_analytic_detections/adhoc_codesigning
+++ b/custom_analytic_detections/adhoc_codesigning
@@ -20,11 +20,15 @@ Name: Ad-hoc signed App Bundle
 Expression: (event.process.args)[LAST]
 
 Type: String
-Name: SHA1HEX
+Name: Bundle CDHash
+Expression: (event.process.args)[LAST].file.signingInfo.hexString
+
+Type: String
+Name: Executable - SHA1HEX
 Expression: (event.process.args)[LAST].file.sha1hex
 
 Type: String
-Name: SHA256HEX
+Name: Executable - SHA256HEX
 Expression: (event.process.args)[LAST].file.sha256hex
 
 # Recommended Analytic Configuration:

--- a/custom_analytic_detections/adhoc_codesigning
+++ b/custom_analytic_detections/adhoc_codesigning
@@ -21,7 +21,7 @@ Expression: (event.process.args)[LAST]
 
 Type: String
 Name: Bundle CDHash
-Expression: (event.process.args)[LAST].file.signingInfo.hexString
+Expression: (event.process.args)[LAST].file.signingInfo.cdhash.hexString
 
 Type: String
 Name: Executable - SHA1HEX


### PR DESCRIPTION
Added a additional Context Item, to capture the cdhash from an bundle in case it's not an executable that's adhoc signed.