### PR TITLE
Task/analytic args improvements

### DIFF
--- a/custom_analytic_detections/adhoc_codesigning
+++ b/custom_analytic_detections/adhoc_codesigning
@@ -12,7 +12,7 @@ Level: 0
 $event.type  == 1 AND
 $event.process.signingInfo.appid == "com.apple.security.codesign" AND
 $event.process.args.@count > 0 AND
-(((ANY $event.process.args  IN {"--sign", "-s"}) AND (ANY $event.process.args == "-")))
+((ANY $event.process.args IN {"--sign", "-s"}) AND (ANY $event.process.args == "-"))
 
 # Context Items:
 Type: File

--- a/custom_analytic_detections/adhoc_codesigning
+++ b/custom_analytic_detections/adhoc_codesigning
@@ -11,8 +11,8 @@ Level: 0
 
 $event.type  == 1 AND
 $event.process.signingInfo.appid == "com.apple.security.codesign" AND
-($event.process.commandLine CONTAINS "--sign" OR $event.process.commandLine CONTAINS " -s") AND
-$event.process.commandLine CONTAINS " - "
+$event.process.args.@count > 0 AND
+(((ANY $event.process.args  IN {"--sign", "-s"}) AND (ANY $event.process.args == "-")))
 
 # Context Items:
 Type: File

--- a/custom_analytic_detections/electron_app_code_injection
+++ b/custom_analytic_detections/electron_app_code_injection
@@ -6,7 +6,8 @@
 
 $event.type  == 1 AND
 $event.process.path CONTAINS ".app" AND
-($event.process.commandLine CONTAINS "--inspect=" OR $event.process.commandLine CONTAINS "--remote-de-bugging-port")
+$event.process.args.@count > 0 AND
+(ANY $event.process.args IN {"--inspect=", "--remote-de-bugging-port"})
 
 
 # Required Analytic Configuration:

--- a/custom_analytic_detections/filevault_authrestart
+++ b/custom_analytic_detections/filevault_authrestart
@@ -6,8 +6,9 @@
 # Analytic Predicate(s):
 
 $event.type == 1 AND 
-$event.process.signingInfo.appid == "com.apple.fdesetup" AND 
-$event.process.commandLine CONTAINS "authrestart"
+$event.process.signingInfo.appid == "com.apple.fdesetup" AND
+$event.process.args.@count > 0 AND
+(ANY $event.process.args == "authrestart")
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/keychain_copied
+++ b/custom_analytic_detections/keychain_copied
@@ -7,7 +7,8 @@
 
 $event.type == 1 AND 
 $event.process.path.lastPathComponent IN {'mv', 'ditto', 'cp'} AND 
-$event.process.commandLine CONTAINS ".keychain-db"
+$event.process.args.@count > 0 AND
+(ANY $event.process.args == ".keychain-db")
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/keychain_dumped
+++ b/custom_analytic_detections/keychain_dumped
@@ -7,7 +7,8 @@
 
 $event.type == 1 AND 
 $event.process.signingInfo.appid == "com.apple.security" AND 
-$event.process.commandLine CONTAINS "dump-keychain"
+$event.process.args.@count > 0 AND
+(ANY $event.process.args == "dump-keychain")
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/launchctl_unload_and_bootout_events
+++ b/custom_analytic_detections/launchctl_unload_and_bootout_events
@@ -6,7 +6,9 @@
 # Analytic Predicate:
 
 $event.type == 1 AND
-$event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND ($event.process.commandLine CONTAINS "unload" OR $event.process.commandLine CONTAINS "bootout") 
+$event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND
+$event.process.args.@count > 0 AND
+(ANY $event.process.args IN {"unload", "bootout"})
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/lockscreen_check
+++ b/custom_analytic_detections/lockscreen_check
@@ -7,7 +7,7 @@
 
 $event.type == 1 AND
 $event.process.path.lastPathComponent == "grep" AND
-$event.process.commandLine CONTAINS[cd] " CGSSession" AND
+(ANY $event.process.args == "CGSSession") AND
 $event.process.pgprocess.signingInfo.appid == "com.apple.ioreg"
 
 # Required Analytic Configuration:

--- a/custom_analytic_detections/mdfind_search_aws_keys
+++ b/custom_analytic_detections/mdfind_search_aws_keys
@@ -7,7 +7,7 @@
 
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.mdfind" AND
-$event.process.commandLine CONTAINS[c] "*AKIA*"
+(ANY $event.process.args CONTAINS[c] "*AKIA*")
 
 # Required Analytic Configuration:
 Sensor Event Type: Process Event

--- a/custom_analytic_detections/osascript_dialog_activity
+++ b/custom_analytic_detections/osascript_dialog_activity
@@ -11,8 +11,8 @@ Level: 0
 
 $event.type  == 1 AND
 $event.process.signingInfo.appid == "com.apple.osascript" AND
-$event.process.commandLine CONTAINS "display dialog" AND
-($event.process.commandLine CONTAINS "Keychain" OR $event.process.commandLine CONTAINS "password" OR $event.process.commandLine CONTAINS "credentials")
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "display dialog") AND (ANY $event.process.args IN {"Keychain", "password", "credentials"}))
 
 # Recommended Analytic Configuration:
 Severity: Informational

--- a/custom_analytic_detections/sfltool_activity
+++ b/custom_analytic_detections/sfltool_activity
@@ -11,7 +11,8 @@ Level: 0
 
 $event.type  == 1 AND
 $event.process.signingInfo.appid == "com.apple.sfltool" AND
-($event.process.commandLine CONTAINS "resetbtm" OR  $event.process.commandLine CONTAINS "dumpbtm")
+$event.process.args.@count > 0 AND
+(ANY $event.process.args IN {"resetbtm", "dumpbtm"})
 
 # Recommended Analytic Configuration:
 Severity: Informational

--- a/custom_analytic_detections/smartcard_config_activity/smartcard_pair_identiy_changes
+++ b/custom_analytic_detections/smartcard_config_activity/smartcard_pair_identiy_changes
@@ -6,10 +6,14 @@
 # Analytic Predicate(s):
 
 Smartcard Identity Paired
-$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.ctkbind" AND $event.process.commandLine CONTAINS " -p "
+$event.type == 1 AND
+$event.process.signingInfo.appid == "com.apple.ctkbind" AND
+(ANY $event.process.args == "-p")
 
 Smartcard Identity Unpaired
-$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.ctkbind" AND $event.process.commandLine CONTAINS " -r "
+$event.type == 1 AND
+$event.process.signingInfo.appid == "com.apple.ctkbind" AND
+(ANY $event.process.args == "-r")
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/smartcard_config_activity/smartcard_pin_changes
+++ b/custom_analytic_detections/smartcard_config_activity/smartcard_pin_changes
@@ -6,10 +6,14 @@
 # Analytic Predicate(s):
 
 Smartcard Change PIN
-$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.pivpin" AND NOT $event.process.commandLine CONTAINS " -v"
+$event.type == 1 AND
+$event.process.signingInfo.appid == "com.apple.pivpin" AND NOT
+(ANY $event.process.args == "-v")
 
 Smartcard Verify PIN
-$event.type == 1 AND $event.process.signingInfo.appid == "com.apple.pivpin" AND $event.process.commandLine CONTAINS " -v"
+$event.type == 1 AND
+$event.process.signingInfo.appid == "com.apple.pivpin" AND
+(ANY $event.process.args == "-v")
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/sqlite3_downloads
+++ b/custom_analytic_detections/sqlite3_downloads
@@ -7,8 +7,8 @@
 
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.sqlite3" AND
-$event.process.commandLine CONTAINS[cd] "com.apple.LaunchServices.QuarantineEventsV" AND
-$event.process.commandLine CONTAINS[cd] "LSQuarantineEvent"
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "com.apple.LaunchServices.QuarantineEventsV") AND (ANY $event.process.args == "LSQuarantineEvent"))
 
 # Required Analytic Configuration:
 Sensor Event Type: Process Event

--- a/custom_analytic_detections/sqlite3_fda
+++ b/custom_analytic_detections/sqlite3_fda
@@ -7,8 +7,8 @@
 
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.sqlite3" AND
-$event.process.commandLine CONTAINS[cd] "tcc.db" AND 
-$event.process.commandLine CONTAINS[cd] "kTCCServiceSystemPolicyAllFiles"
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "tcc.db") AND (ANY $event.process.args == "kTCCServiceSystemPolicyAllFiles"))
 
 # Required Analytic Configuration:
 Sensor Event Type: Process Event

--- a/custom_analytic_detections/system_config_activity/application_firewall_config_changes
+++ b/custom_analytic_detections/system_config_activity/application_firewall_config_changes
@@ -13,8 +13,10 @@
 
 # Analytic Predicate(s):
 
-$event.type == 1 AND
-$event.process.signingInfo.appid == "com.apple.socketfilterfw" AND ($event.process.commandLine CONTAINS[cd] "--setglobalstate off" OR $event.process.commandLine CONTAINS[cd] "--setloggingmode off" OR $event.process.commandLine CONTAINS[cd] "--unblockapp" OR $event.process.commandLine CONTAINS[cd] "--setblockall off" OR $event.process.commandLine CONTAINS[cd] "--remove")
+$event.type == 1 AND 
+$event.process.signingInfo.appid == "com.apple.socketfilterfw" AND 
+$event.process.args.@count > 0 AND
+(((ANY $event.process.args  IN {"--setglobalstate", "--setloggingmode", "--setblockall"}) AND (ANY $event.process.args == "off")) OR (ANY $event.process.args IN {"--unblockapp", "--remove"}))
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/system_config_activity/builtin_apache_config_changes
+++ b/custom_analytic_detections/system_config_activity/builtin_apache_config_changes
@@ -8,14 +8,14 @@
 Apache Enabled
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND
-$event.process.commandLine CONTAINS[cd] " load " AND
-$event.process.commandLine CONTAINS[cd] "/System/Library/LaunchDaemons/org.apache.httpd.plist"
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "load") AND (ANY $event.process.args == "/System/Library/LaunchDaemons/org.apache.httpd.plist"))
 
 Apache Disabled
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND
-$event.process.commandLine CONTAINS[cd] " unload " AND
-$event.process.commandLine CONTAINS[cd] "/System/Library/LaunchDaemons/org.apache.httpd.plist"
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "unload") AND (ANY $event.process.args == "/System/Library/LaunchDaemons/org.apache.httpd.plist"))
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/system_config_activity/file_sharing_config_changes
+++ b/custom_analytic_detections/system_config_activity/file_sharing_config_changes
@@ -8,14 +8,14 @@
 File Sharing Enabled
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND
-$event.process.commandLine CONTAINS[cd] " load " AND
-$event.process.commandLine CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "load") AND (ANY $event.process.args == "/System/Library/LaunchDaemons/com.apple.smbd.plist"))
 
 File Sharing Disabled
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.xpc.launchctl" AND
-$event.process.commandLine CONTAINS[cd] " unload " AND
-$event.process.commandLine CONTAINS[cd] "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+$event.process.args.@count > 0 AND
+((ANY $event.process.args == "unload") AND (ANY $event.process.args == "/System/Library/LaunchDaemons/com.apple.smbd.plist"))
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/system_config_activity/gatekeeper_config_changes
+++ b/custom_analytic_detections/system_config_activity/gatekeeper_config_changes
@@ -10,8 +10,9 @@
 
 # Analytic Predicate(s):
 
-$event.type == 1 AND
-$event.process.signingInfo.appid == "com.apple.spctl" AND ($event.process.commandLine CONTAINS[cd] " --global-disable " OR $event.process.commandLine CONTAINS[cd] " --master-disable " OR $event.process.commandLine CONTAINS[cd] " --disable " OR $event.process.commandLine CONTAINS[cd] " --remove ")
+$event.type == 1 AND 
+$event.process.signingInfo.appid == "com.apple.spctl" AND 
+(ANY $event.process.args IN {"--global-disable", "--master-disable", "--disable", "--remove"})
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/systemsetup_activity
+++ b/custom_analytic_detections/systemsetup_activity
@@ -12,7 +12,8 @@ Level: 0
 
 $event.type  == 1 AND
 $event.process.signingInfo.appid == "com.apple.systemsetup" AND
-($event.process.commandLine CONTAINS "setremoteappleevents" OR  $event.process.commandLine CONTAINS "setremotelogin")
+$event.process.args.@count > 0 AND
+(ANY $event.process.args IN {"setremoteappleevents", "setremotelogin"})
 
 # Recommended Analytic Configuration:
 Severity: Informational

--- a/custom_analytic_detections/tmutil_activity
+++ b/custom_analytic_detections/tmutil_activity
@@ -11,7 +11,8 @@ Level: 0
 $event.process.signingInfo.appid == "com.apple.timemachine.tmutil" AND
 $event.type == 1 AND
 $event.process.tty == nil AND
-(($event.process.commandLine CONTAINS[c] "deletelocalsnapshots" AND $event.process.commandLine CONTAINS "/") OR ($event.process.commandLine CONTAINS[c] "delete"))
+$event.process.args.@count > 0 AND
+(((ANY $event.process.args == "deletelocalsnapshots") AND (ANY $event.process.args == "/")) OR (ANY $event.process.args == "delete"))
 
 # Recommended Analytic Configuration:
 Severity: Informational

--- a/custom_analytic_detections/user_created_by_dscl
+++ b/custom_analytic_detections/user_created_by_dscl
@@ -7,7 +7,7 @@
 
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.dscl" AND
-$event.process.commandLine CONTAINS " -create "
+(ANY $event.process.args == "-create")
 
 # Required Analytic Configuration:
 

--- a/custom_analytic_detections/user_deleted_by_dscl
+++ b/custom_analytic_detections/user_deleted_by_dscl
@@ -7,7 +7,7 @@
 
 $event.type == 1 AND
 $event.process.signingInfo.appid == "com.apple.dscl" AND
-$event.process.commandLine CONTAINS " -delete "
+(ANY $event.process.args == "-delete")
 
 # Required Analytic Configuration:
 


### PR DESCRIPTION
Migration primarily from the use of `.commandLine` to `.args` to be able to iterate through an array of arguments, this should be safer and more specific and in some cases less recalculations of the same data again.

As example: `(ANY $event.process.args IN {"something", "somethingelse"})`