### PR TITLE
scp_file_copied_remote_destination

### DIFF
--- a/custom_analytic_detections/scp_file_copied_remote_destination
+++ b/custom_analytic_detections/scp_file_copied_remote_destination
@@ -1,0 +1,30 @@
+# scp_file_copied_remote_destination
+#
+# This Analytic predicate may be used to report when scp is used to copy a file to a remote destination.
+#
+
+# Required Analytic Configuration:
+Sensor Event Type: Process Event
+Level: 0
+
+# Analytic Predicate:
+
+$event.process.signingInfo.appid == "com.apple.scp" AND
+$event.type == 1 AND
+$event.process.args.@count > 1 AND
+(ANY $event.process.args MATCHES ".*@.*")
+
+# Context Items:
+Type: File
+Name: Source file
+Expression: (event.process.args)[1]
+
+Type: String
+Name: Destination
+Expression: (event.process.args)[LAST]
+
+
+# Recommended Analytic Configuration:
+Severity: Informational
+Categories: Visibility
+Tags: Exfiltration


### PR DESCRIPTION
Custom Analytic to detect the use of `scp` to transfer files to a remote destination.
provided Context Items could highlight source file and destination paths.

![image](https://github.com/jamf/jamfprotect/assets/26306960/19cd6b4d-f71e-4cf3-9bb9-ed02e918717a)
