### PR TITLE
S3 diagnostics fixes

### DIFF
--- a/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
+++ b/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
@@ -98,7 +98,6 @@ CollectArchive () {
 		# Check for the AWS binary. If not present, install.
 		if [[ ! -f "$awsBinary" ]]; then    
 			/usr/bin/curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o /tmp/AWSCLIV2.pkg
-			/usr/sbin/installer -pkg /tmp/AWSCLIV2.pkg -target /
 		
 			# Verify the download
 			teamID=$(/usr/sbin/spctl -a -vv -t install "/tmp/AWSCLIV2.pkg" 2>&1 | awk '/origin=/ {print $NF }' | tr -d '()')
@@ -194,4 +193,3 @@ startDiagnostics
 CheckForFiles
 NetworkCheckAndUpload 
 CleanUp
-

--- a/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
+++ b/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
@@ -61,9 +61,6 @@ awsFolder=""
 # Getting logged in user
 loggedInUser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
 
-# Find files that match the pattern on the users desktop
-diagnostics_files=$(find /Users/"$loggedInUser"/Desktop -name 'JamfProtectDiagnostics*.*.zip' -a -mmin +10)
-
 # Expected AWS CLI Binary TeamID
 expectedAwscliTeamID="94KV3E626L"
 
@@ -82,6 +79,9 @@ startDiagnostics () {
 
 # Checks for the Jamf Protect Diagnostics archive to confirm if the script should continue
 CheckForFiles () {
+	# Find files that match the pattern on the users desktop
+	diagnostics_files=$(find /Users/"$loggedInUser"/Desktop -name 'JamfProtectDiagnostics*.*.zip' -a -mmin +10)
+
 	if [ -n "$diagnostics_files" ]; then
 		echo "Jamf Protect Diagnostic Files found"
 		echo "$diagnostics_files"

--- a/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
+++ b/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
@@ -192,7 +192,6 @@ CleanUp () {
 
 startDiagnostics
 CheckForFiles
-CollectArchive
 NetworkCheckAndUpload 
 CleanUp
 

--- a/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
+++ b/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
@@ -80,7 +80,7 @@ startDiagnostics () {
 # Checks for the Jamf Protect Diagnostics archive to confirm if the script should continue
 CheckForFiles () {
 	# Find files that match the pattern on the users desktop
-	diagnostics_files=$(find /Users/"$loggedInUser"/Desktop -name 'JamfProtectDiagnostics*.*.zip' -a -mmin +10)
+	diagnostics_files=$(find /Users/"$loggedInUser"/Desktop -name 'JamfProtectDiagnostics*.*.zip' -a -mmin -10)
 
 	if [ -n "$diagnostics_files" ]; then
 		echo "Jamf Protect Diagnostic Files found"

--- a/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
+++ b/helper_tools/jamf_protect_diagnostics/aws_s3/jp_diagnostics_self_service.sh
@@ -194,5 +194,5 @@ startDiagnostics
 CheckForFiles
 CollectArchive
 NetworkCheckAndUpload 
-cleanUp
+CleanUp
 


### PR DESCRIPTION
A few minor fixes for the s3 workflow.
- Fixed a capitalization issue in a function name so cleanup runs correctly
- Adjusted logic for the file checker to be "within the last 10 minutes" not "older than 10 minutes"
- Moved file checker into the correct function to check for file existence after file creation not before
- Removed redundant upload call
- Removed redundant CLI install