### PR TITLE
New EA for Web Protection and a new custom Analytic

### DIFF
--- a/custom_analytic_detections/installer_initiated_network_connection
+++ b/custom_analytic_detections/installer_initiated_network_connection
@@ -1,0 +1,19 @@
+# installer_initiated_network_connection
+#
+# This Analytic predicate may be used to report on the Installer process invoking nscurl or curl when a pre or post install script has ran, potentially retrieving files from a remote server.
+# This detection functions by monitoring for the process creation involving curl or nscurl where the responsible process is Installer and the parent process is a shell.
+#
+# Analytic Predicate:
+
+$event.type == 1 AND
+$event.process.path.lastPathComponent IN {"curl", "nscurl"} AND
+$event.process.parent.isShell == true AND
+$event.process.responsible.path.lastPathComponent == "Installer"
+
+# Required Analytic Configuration:
+
+Sensor Event Type: Process Event
+Level: 0
+
+# Recommended Analytic Configuration:
+Severity: Informational

--- a/jamf_pro_extension_attributes/jamf_protect_WebProtection.sh
+++ b/jamf_pro_extension_attributes/jamf_protect_WebProtection.sh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+# This Extension Attribute will report on the state of Web Protection.
+#
+# Data Type: String
+# Input Type: Script
+#
+##### Script starts here #####
+
+#Jamf Protect Location
+jamfProtectBinaryLocation="/usr/local/bin/protectctl"
+
+if [ -f "$jamfProtectBinaryLocation" ]; then
+  plist=$($jamfProtectBinaryLocation info --plist)
+  jamfProtectWebProtection=$(/usr/libexec/PlistBuddy -c "Print :Plan:WebProtection" /dev/stdin <<<"$plist")
+else
+  jamfProtectWebProtection="Protect binary not found"
+fi
+
+echo "<result>$jamfProtectWebProtection</result>"


### PR DESCRIPTION
- **jamf_protect_WebProtection.sh**
  - Extension Attribute for retrieving the state of Web Protection
- **installer_initiated_network_connection**
  - A custom Analytic to monitor the invocation of `curl`, `nscurl` where the responsible process is `Installer`. Could indicate that when running a `.pkg` a pre/post install script retrieves additional payloads from a remote server.  