### PR TITLE
Predicate only checks for "-create" option but dscl supports "create" option as well

### DIFF
--- a/custom_analytic_detections/hidden_account_created_dscl.yaml
+++ b/custom_analytic_detections/hidden_account_created_dscl.yaml
@@ -8,7 +8,7 @@ tags:
 snapshotFiles: []
 filter: $event.type == 1 AND
   ($event.process.path.lastPathComponent == "dscl" AND
-  ((ANY $event.process.args == "IsHidden") AND (ANY $event.process.args == "-create") AND (ANY $event.process.args IN {"true", "1", "yes"})))
+  ((ANY $event.process.args == "IsHidden") AND (ANY $event.process.args IN {"-create", "create"}) AND (ANY $event.process.args IN {"true", "1", "yes"})))
 actions:
   - name: Log
 context: []


### PR DESCRIPTION
The original analytic only looks for the use of "-create" however the Directory Services Command Line tool (dscl) includes a the create option without the leading '-' that also will create the hidden account flag in a local account. The predicate as written does not trigger if the '-' is omitted from create, but this updated predicate will.